### PR TITLE
Accesskit labels for tabs, separators and tab bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - `SeparatorStyle::junction_merge_distance`: maximum distance between two perpendicular separators
   that could be dragged as one junction.
 - `SeparatorStyle::arrow_key_step_distance`: how far a focused separator moves per arrow key press.
-- Accessibility (AccessKit) support for tabs, separators and tab bars.
+- Accessibility (AccessKit) support for tabs, separators and tab bars ([#345](https://github.com/anhosh/egui_dock/pull/345)).
 
 ## egui_dock 0.21.1 - 2026/08/06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `SeparatorStyle::junction_merge_distance`: maximum distance between two perpendicular separators
   that could be dragged as one junction.
 - `SeparatorStyle::arrow_key_step_distance`: how far a focused separator moves per arrow key press.
+- Accessibility (AccessKit) support for tabs, separators and tab bars.
 
 ## egui_dock 0.21.1 - 2026/08/06
 

--- a/src/dock_state/translations.rs
+++ b/src/dock_state/translations.rs
@@ -10,6 +10,8 @@ pub struct Translations {
     pub tab_context_menu: TabContextMenuTranslations,
     /// Text overrides for buttons in windows.
     pub leaf: LeafTranslations,
+    /// Screen-reader labels for buttons without visible text.
+    pub accessibility: AccessibilityTranslations,
 }
 
 /// Specifies text in buttons displayed in the context menu displayed upon right-clicking on a tab.
@@ -68,12 +70,36 @@ pub struct LeafTranslations {
     pub minimize_button_modifier_menu_hint: String,
 }
 
+/// Specifies labels reported to screen readers (via AccessKit) for buttons that
+/// have no visible text.
+#[derive(Clone, Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(default)
+)]
+pub struct AccessibilityTranslations {
+    /// Label of the close tab button.
+    pub close_button: String,
+    /// Label of the add tab button.
+    pub add_button: String,
+    /// Label of the close all tabs button.
+    pub close_all_button: String,
+    /// Label of the collapse button of a collapsed leaf.
+    pub collapse_button: String,
+    /// Label of the expand button of a collapsed leaf.
+    pub expand_button: String,
+    /// Label of the expand button of a collapsed window.
+    pub expand_window_button: String,
+}
+
 impl Translations {
     /// Default English translations.
     pub fn english() -> Self {
         Self {
             tab_context_menu: TabContextMenuTranslations::english(),
             leaf: LeafTranslations::english(),
+            accessibility: AccessibilityTranslations::english(),
         }
     }
 }
@@ -131,6 +157,26 @@ impl LeafTranslations {
 }
 
 impl Default for LeafTranslations {
+    fn default() -> Self {
+        Self::english()
+    }
+}
+
+impl AccessibilityTranslations {
+    /// Default English translations.
+    pub fn english() -> Self {
+        Self {
+            close_button: String::from("Close tab"),
+            add_button: String::from("Add tab"),
+            close_all_button: String::from("Close all tabs"),
+            collapse_button: String::from("Collapse leaf"),
+            expand_button: String::from("Expand leaf"),
+            expand_window_button: String::from("Expand window"),
+        }
+    }
+}
+
+impl Default for AccessibilityTranslations {
     fn default() -> Self {
         Self::english()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,11 +248,11 @@
 //! dock_state.translations.leaf.minimize_button_modifier_hint = "修飾キー（デフォルトではShift）を押すと、このウィンドウが最小化されます".to_string();
 //! dock_state.translations.leaf.minimize_button_modifier_menu_hint = "修飾キー（デフォルトではShift）を押すか、右クリックしてこのウィンドウを最小化する".to_string();
 //! dock_state.translations.accessibility.close_button = "タブを閉じる".to_string();
-//! dock_state.translations.accessibility.add_button = "タブを追加する".to_string();
+//! dock_state.translations.accessibility.add_button = "タブを追加".to_string();
 //! dock_state.translations.accessibility.close_all_button = "すべてのタブを閉じる".to_string();
 //! dock_state.translations.accessibility.collapse_button = "ノードを折りたたむ".to_string();
-//! dock_state.translations.accessibility.expand_button = "ノードを展開する".to_string();
-//! dock_state.translations.accessibility.expand_window_button = "ウィンドウを展開する".to_string();
+//! dock_state.translations.accessibility.expand_button = "ノードを展開".to_string();
+//! dock_state.translations.accessibility.expand_window_button = "ウィンドウを展開".to_string();
 //! ```
 
 #![warn(missing_docs)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,7 @@
 //! Example usage:
 //!
 //! ```rust
-//! # use egui_dock::{DockState, TabContextMenuTranslations, Translations, LeafTranslations};
+//! # use egui_dock::{AccessibilityTranslations, DockState, TabContextMenuTranslations, Translations, LeafTranslations};
 //! # type Tab = ();
 //! let translations_pl = Translations {
 //!     tab_context_menu: TabContextMenuTranslations {
@@ -219,6 +219,14 @@
 //!         minimize_button_menu_hint: "Kliknij prawym przyciskiem myszy, aby zminimalizować to okno.".to_string(),
 //!         minimize_button_modifier_hint: "Naciśnij klawisze modyfikujące (domyślnie Shift), aby zminimalizować to okno.".to_string(),
 //!         minimize_button_modifier_menu_hint: "Naciśnij klawisze modyfikujące (domyślnie Shift) lub kliknij prawym przyciskiem myszy, aby zminimalizować to okno.".to_string(),
+//!     },
+//!     accessibility: AccessibilityTranslations {
+//!         close_button: "Zamknij zakładkę".to_string(),
+//!         add_button: "Dodaj zakładkę".to_string(),
+//!         close_all_button: "Zamknij wszystkie zakładki".to_string(),
+//!         collapse_button: "Zwiń węzeł".to_string(),
+//!         expand_button: "Rozwiń węzeł".to_string(),
+//!         expand_window_button: "Rozwiń okno".to_string(),
 //!     }
 //! };
 //! let dock_state = DockState::<Tab>::new(vec![]).with_translations(translations_pl);
@@ -239,6 +247,12 @@
 //! dock_state.translations.leaf.minimize_button_menu_hint = "右クリックでウィンドウを最小化する".to_string();
 //! dock_state.translations.leaf.minimize_button_modifier_hint = "修飾キー（デフォルトではShift）を押すと、このウィンドウが最小化されます".to_string();
 //! dock_state.translations.leaf.minimize_button_modifier_menu_hint = "修飾キー（デフォルトではShift）を押すか、右クリックしてこのウィンドウを最小化する".to_string();
+//! dock_state.translations.accessibility.close_button = "タブを閉じる".to_string();
+//! dock_state.translations.accessibility.add_button = "タブを追加する".to_string();
+//! dock_state.translations.accessibility.close_all_button = "すべてのタブを閉じる".to_string();
+//! dock_state.translations.accessibility.collapse_button = "ノードを折りたたむ".to_string();
+//! dock_state.translations.accessibility.expand_button = "ノードを展開する".to_string();
+//! dock_state.translations.accessibility.expand_window_button = "ウィンドウを展開する".to_string();
 //! ```
 
 #![warn(missing_docs)]

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -3,8 +3,8 @@ use std::ops::RangeInclusive;
 use egui::{
     Align, Align2, Button, Color32, CornerRadius, CursorIcon, Frame, Id, Key, LayerId, Layout,
     NumExt, Order, Popup, PopupCloseBehavior, Rect, Response, ScrollArea, Sense, Shape, Stroke,
-    StrokeKind, TextStyle, Ui, UiBuilder, Vec2, WidgetText, emath::TSTransform, epaint::TextShape,
-    lerp, pos2, vec2,
+    StrokeKind, TextStyle, Ui, UiBuilder, Vec2, WidgetInfo, WidgetText, WidgetType, accesskit,
+    emath::TSTransform, epaint::TextShape, lerp, pos2, vec2,
 };
 
 use crate::NodePath;
@@ -138,6 +138,17 @@ impl<Tab> DockArea<'_, Tab> {
             .with((path.node, "node"))
             .with("show_tab_bar_btn");
         let btn_response = ui.interact(btn_rect, btn_id, Sense::click());
+        btn_response.widget_info(|| {
+            WidgetInfo::labeled(
+                WidgetType::Button,
+                ui.is_enabled(),
+                &self
+                    .dock_state
+                    .translations
+                    .tab_context_menu
+                    .show_tab_bar_button,
+            )
+        });
         let (draw_rect, color) = if btn_response.hovered() {
             let expanded_size = Vec2::splat(btn_size + btn_expand);
             (
@@ -624,6 +635,13 @@ impl<Tab> DockArea<'_, Tab> {
         let (rect, mut response) = ui.allocate_exact_size(ui.available_size(), Sense::click());
 
         response = response.on_hover_cursor(CursorIcon::PointingHand);
+        response.widget_info(|| {
+            WidgetInfo::labeled(
+                WidgetType::Button,
+                ui.is_enabled(),
+                &self.dock_state.translations.accessibility.add_button,
+            )
+        });
 
         let style = fade_style.unwrap_or_else(|| self.style.as_ref().unwrap());
         let color = if response.hovered() || response.has_focus() {
@@ -702,6 +720,16 @@ impl<Tab> DockArea<'_, Tab> {
 
         // Whether we're on "secondary button mode" due to modifier keys
         let on_secondary_button = self.is_on_secondary_button(path.surface, ui, &response);
+
+        response.widget_info(|| {
+            let translations = &self.dock_state.translations;
+            let (label, enabled) = if on_secondary_button {
+                (&translations.leaf.close_all_button, !close_window_disabled)
+            } else {
+                (&translations.accessibility.close_all_button, !disabled)
+            };
+            WidgetInfo::labeled(WidgetType::Button, ui.is_enabled() && enabled, label)
+        });
 
         let mut stroke_color = if disabled {
             style.buttons.close_all_tabs_disabled_color
@@ -839,6 +867,18 @@ impl<Tab> DockArea<'_, Tab> {
 
         // Whether we're on "secondary button mode" due to modifier keys
         let on_secondary_button = self.is_on_secondary_button(path.surface, ui, &response);
+
+        response.widget_info(|| {
+            let translations = &self.dock_state.translations;
+            let label = if on_secondary_button {
+                &translations.leaf.minimize_button
+            } else if collapsed {
+                &translations.accessibility.expand_button
+            } else {
+                &translations.accessibility.collapse_button
+            };
+            WidgetInfo::labeled(WidgetType::Button, ui.is_enabled(), label)
+        });
 
         let color = if response.hovered() || response.has_focus() {
             ui.painter().rect_filled(
@@ -1090,6 +1130,7 @@ impl<Tab> DockArea<'_, Tab> {
         fade: Option<&Style>,
     ) -> (Response, Option<Response>) {
         let style = fade.unwrap_or_else(|| self.style.as_ref().unwrap());
+        let title = label.text().to_owned();
         let galley = label.into_galley(ui, None, f32::INFINITY, TextStyle::Button);
         let x_spacing = 8.0;
         let text_width = galley.size().x + 2.0 * x_spacing;
@@ -1108,6 +1149,14 @@ impl<Tab> DockArea<'_, Tab> {
 
         let (_, tab_rect) = ui.allocate_space(vec2(tab_width, ui.available_height()));
         let mut response = ui.interact(tab_rect, id, Sense::click_and_drag());
+        response.widget_info(|| {
+            WidgetInfo::selected(WidgetType::Button, ui.is_enabled(), active, &title)
+        });
+        ui.ctx().accesskit_node_builder(response.id, |node| {
+            node.set_role(accesskit::Role::Tab);
+            node.set_selected(active);
+            node.clear_toggled();
+        });
         if ui.ctx().dragged_id().is_none() && self.draggable_tabs {
             response = response.on_hover_cursor(CursorIcon::Grab);
         }
@@ -1174,6 +1223,13 @@ impl<Tab> DockArea<'_, Tab> {
             let close_response = ui
                 .interact(close_button_rect, id.with("close-button"), Sense::click())
                 .on_hover_cursor(CursorIcon::PointingHand);
+            close_response.widget_info(|| {
+                WidgetInfo::labeled(
+                    WidgetType::Button,
+                    ui.is_enabled(),
+                    &self.dock_state.translations.accessibility.close_button,
+                )
+            });
 
             let color = if close_response.hovered() || close_response.has_focus() {
                 style.buttons.close_tab_active_color
@@ -1263,6 +1319,7 @@ impl<Tab> DockArea<'_, Tab> {
                     self.id.with((path.node, "node")),
                     Sense::drag(),
                 );
+                scroll_bar_handle_response.widget_info(|| WidgetInfo::new(WidgetType::ScrollBar));
 
                 // Coefficient to apply to input displacements so that we move the scroll by the correct amount.
                 let points_to_scroll_coefficient =

--- a/src/widgets/dock_area/show/separator.rs
+++ b/src/widgets/dock_area/show/separator.rs
@@ -337,7 +337,7 @@ impl<Tab> DockArea<'_, Tab> {
             let id = self.id.with("separator_junction").with(&paths);
 
             // Junctions should sense click and drags but not focus.
-            // NOTE: don't use `Sense::click_and_drag()` here because it sets `Self::FOCUSABLE` as well.
+            // NOTE: don't use `Sense::click_and_drag()` here because it sets `Sense::FOCUSABLE` as well.
             let response = ui
                 .interact(interact_rect, id, Sense::CLICK | Sense::DRAG)
                 .on_hover_and_drag_cursor(CursorIcon::Move);

--- a/src/widgets/dock_area/show/separator.rs
+++ b/src/widgets/dock_area/show/separator.rs
@@ -1,5 +1,8 @@
 use duplicate::duplicate;
-use egui::{CornerRadius, CursorIcon, EventFilter, Key, Rect, Response, Sense, Ui, Vec2, vec2};
+use egui::{
+    CornerRadius, CursorIcon, EventFilter, Key, Rect, Response, Sense, Ui, Vec2, WidgetInfo,
+    WidgetType, accesskit, vec2,
+};
 use paste::paste;
 
 use crate::{
@@ -201,9 +204,9 @@ impl<Tab> DockArea<'_, Tab> {
 
         duplicate! {
             [
-                orientation   dim_point  dim_size  sep_axis;
-                [Horizontal]  [x]        [width]   [X];
-                [Vertical]    [y]        [height]  [Y];
+                orientation   dim_point  dim_size  sep_axis  ak_orientation;
+                [Horizontal]  [x]        [width]   [X]       [Vertical];
+                [Vertical]    [y]        [height]  [Y]       [Horizontal];
             ]
             if let Node::orientation(split) = &mut self.dock_state[path.surface][path.node] {
                 let rect = split.rect;
@@ -219,6 +222,8 @@ impl<Tab> DockArea<'_, Tab> {
 
                 let response = ui.allocate_rect(interact_rect, Sense::click_and_drag())
                     .on_hover_and_drag_cursor(paste!{ CursorIcon::[<Resize orientation>]});
+
+                response.widget_info(|| WidgetInfo::new(WidgetType::ResizeHandle));
 
                 let arrow_key_offset = arrow_key_offset(ui, &response, style.separator.arrow_key_step_distance);
 
@@ -254,12 +259,42 @@ impl<Tab> DockArea<'_, Tab> {
                 // Update 'fraction' interaction after drawing separator,
                 // otherwise it may overlap on other separator / bodies when
                 // shrunk fast.
-                let delta = arrow_key_offset.unwrap_or(response.drag_delta());
+                let ak_steps = ui.input(|input| {
+                    input.num_accesskit_action_requests(response.id, accesskit::Action::Increment) as f32
+                        - input.num_accesskit_action_requests(response.id, accesskit::Action::Decrement) as f32
+                });
+                let ak_set_value = ui.input(|input| {
+                    input
+                        .accesskit_action_requests(response.id, accesskit::Action::SetValue)
+                        .find_map(|request| match request.data {
+                            Some(accesskit::ActionData::NumericValue(value)) => Some(value as f32),
+                            _ => None,
+                        })
+                });
+                let mut delta = arrow_key_offset.unwrap_or(response.drag_delta());
+                delta.dim_point += ak_steps * style.separator.arrow_key_step_distance;
+                if let Some(value) = ak_set_value {
+                    delta.dim_point += (value.clamp(0.0, 1.0) - split.fraction) * rect.dim_size();
+                }
                 apply_separator_delta(split, SeparatorAxis::sep_axis, delta, &style.separator);
 
                 if response.double_clicked() {
                     split.fraction = 0.5;
                 }
+
+                // Allow assistive technologies to adjust the separator fraction.
+                let fraction = split.fraction;
+                let step = style.separator.arrow_key_step_distance / rect.dim_size().max(1.0);
+                ui.ctx().accesskit_node_builder(response.id, |node| {
+                    node.set_orientation(accesskit::Orientation::ak_orientation);
+                    node.set_numeric_value(fraction.into());
+                    node.set_min_numeric_value(0.0);
+                    node.set_max_numeric_value(1.0);
+                    node.set_numeric_value_step(step.into());
+                    node.add_action(accesskit::Action::Increment);
+                    node.add_action(accesskit::Action::Decrement);
+                    node.add_action(accesskit::Action::SetValue);
+                });
             }
         }
 
@@ -300,9 +335,15 @@ impl<Tab> DockArea<'_, Tab> {
                 junction.members.iter().map(|&m| handles[m].path).collect();
             paths.sort_unstable_by_key(|path| (path.surface.0, path.node.0));
             let id = self.id.with("separator_junction").with(&paths);
+
+            // Junctions should sense click and drags but not focus.
+            // NOTE: don't use `Sense::click_and_drag()` here because it sets `Self::FOCUSABLE` as well.
             let response = ui
-                .interact(interact_rect, id, Sense::click_and_drag())
+                .interact(interact_rect, id, Sense::CLICK | Sense::DRAG)
                 .on_hover_and_drag_cursor(CursorIcon::Move);
+            response.widget_info(|| WidgetInfo::new(WidgetType::ResizeHandle));
+            ui.ctx()
+                .accesskit_node_builder(response.id, |node| node.set_hidden());
 
             if response.drag_started() {
                 state.dragged_junction = Some(

--- a/src/widgets/dock_area/show/window_surface.rs
+++ b/src/widgets/dock_area/show/window_surface.rs
@@ -1,6 +1,6 @@
 use egui::{
     Align, Color32, CornerRadius, CursorIcon, Frame, Layout, Rect, Response, RichText, Sense,
-    Shape, Stroke, Ui, UiBuilder, Vec2, WidgetText, vec2,
+    Shape, Stroke, Ui, UiBuilder, Vec2, WidgetInfo, WidgetText, WidgetType, vec2,
 };
 
 use crate::{
@@ -170,6 +170,17 @@ impl<Tab> DockArea<'_, Tab> {
         let (rect, mut response) = ui.allocate_exact_size(ui.available_size(), Sense::click());
 
         response = response.on_hover_cursor(CursorIcon::PointingHand);
+        response.widget_info(|| {
+            WidgetInfo::labeled(
+                WidgetType::Button,
+                ui.is_enabled(),
+                &self
+                    .dock_state
+                    .translations
+                    .accessibility
+                    .expand_window_button,
+            )
+        });
 
         let style = fade_style.unwrap_or_else(|| self.style.as_ref().unwrap());
         let color = if response.hovered() || response.has_focus() {


### PR DESCRIPTION
Closes #344.

Had to resort to `ui.ctx().accesskit_node_builder(...)` at a few places because:
1. egui doesn't have `WidgetType::Tab` or similar. Opened an issue upstream: https://github.com/emilk/egui/issues/8474
2. We want to allow for AccessKit actions on separators (to adjust the fractions).
3. We want to hide junctions (#338) from AccessKit, since free-moving junctions doesn't make much sense on assistive technologies like VoiceOver.

Tested with VoiceOver on macOS and egui_mcp with Claude Code. Here's a recording of me using VoiceOver on the hello example:

https://github.com/user-attachments/assets/e2502d89-811b-4d51-a62b-9ee712325b0e

There is a "collapsed on left/top" announced on separators, which seems to be an upstream AccessKit macOS adaptor issue.

## AI Disclosure

Claude Code on Fable 5 (Effort Extra) has been used to generate code and it genuinely was NOT particularly useful when it comes to dealing with a11y issues. I have reviewed every line of code generated and edited its output, and wrote many code it fails to generate correctly any way.

I have also used it to generate the Polish and Japanese example translations. I am not a speaker of either, so I couldn't really check those.